### PR TITLE
Rendering of 404 not found JSON view not working

### DIFF
--- a/SlimJson/View.php
+++ b/SlimJson/View.php
@@ -32,7 +32,7 @@ class View extends \Slim\View {
     }
 
     $app->response()->header('Content-Type', 'application/json');
-    $app->response()->body(json_encode($response));
+    return json_encode($response);
   }
 
 }

--- a/SlimJson/View.php
+++ b/SlimJson/View.php
@@ -14,7 +14,7 @@ class View extends \Slim\View {
   public function render($status, $data = null)
   {
     $app = Slim::getInstance();
-    $response = $this->all();
+    $response = array_merge($this->all(), (array) $data);
 
     $status = \intval($status);
     $app->response()->status($status);
@@ -34,5 +34,4 @@ class View extends \Slim\View {
     $app->response()->header('Content-Type', 'application/json');
     return json_encode($response);
   }
-
 }


### PR DESCRIPTION
When setting json.override_notfound to true I didn't get a JSON response. 

After some research I found the following solution: 

The render method should return the rendered content according to the Slim documentation on: http://docs.slimframework.com/#Custom-Views

This fixed it for me, let me know if it breaks something else :)

Thanks for sharing this project. It really helped me getting started on my own REST API.