### PR TITLE
Cors: check origin against a list of allowed hosts

### DIFF
--- a/SlimJson/Middleware.php
+++ b/SlimJson/Middleware.php
@@ -101,15 +101,18 @@ class Middleware extends \Slim\Middleware {
       $cors = $app->config(Config::Cors);
       if ($cors) {
         if(\is_callable($cors)) {
-          $origin = \call_user_func($cors, $app->request());
+          $allowOrigin = \call_user_func($cors, $app->request()->headers->get('Origin'));
         } else {
           if (!\is_string($cors)) {
-            $origin = '*';
+            $allowOrigin = '*';
           } else {
-            $origin = $cors;
+            $allowOrigin = $cors;
           }
         }
-        $app->response()->header('Access-Control-Allow-Origin', $origin);
+
+        if($allowOrigin) {
+          $app->response()->header('Access-Control-Allow-Origin', $allowOrigin);
+        }
       }
 
       if ($app->config(Config::Protect)) {


### PR DESCRIPTION
For CORS I wanted to be able to check the request origin on a list of allowed hosts.

I implemented it like this : 

```
$app->add(new \SlimJson\Middleware(array(
    'json.cors' => function($requestOrigin) {

        $allowed = array(
            'http://localhost:9000',
            'http://www.domain.com',
            'http://domain.com'
        );

        if(in_array($requestOrigin, $allowed)) {
            return $requestOrigin;
        } else {
            return false;
        }
    },
```

Now when the requestOrigin is in the list of allowed hosts it returns the request origin and shows the 'Access-Control-Allow-Origin' header. If it is not in the allowed hosts list it returns false and skips setting the 'Access-Control-Allow-Origin' header.

This change should be backwards compatible with the old json.cors config.
