### PR TITLE
Fix composer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SlimJson is an easy-to-use and advanced JSON middleware for Slim PHP framework. 
 ## How to install
 You can install SlimJson with Composer by:
 ```
-composer install dogancelik/slim-json
+composer require dogancelik/slim-json
 ```
 or adding this line to your `composer.json` file:
 ```


### PR DESCRIPTION
`composer install dogancelik/slim-json` gives the following error: `Invalid argument dogancelik/slim-json. Use "composer require dogancelik/slim-json" instead to add packages to your composer.json.`.